### PR TITLE
Support asynchronous logic using promises

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,11 @@ export default store => next => action => {
   const posthooks =  getTheHooksAt('post')
 
   prehooks.forEach(hook => hook(store, action))
-  next(action)
-  posthooks.forEach(hook => hook(store, action))
+
+  const result = next(action)
+
+  return Promise.resolve(result)
+    .then(() => {
+      posthooks.forEach(hook => hook(store, action))
+    })
 }

--- a/test/e2e/redux.test.js
+++ b/test/e2e/redux.test.js
@@ -28,8 +28,10 @@ const reducer = (state = { case: '' }, action) => {
  */
 const createSpyMiddleware = (preSpy, postSpy) => store => next => action => {
   preSpy(store.getState())
-  next(action)
-  postSpy(store.getState())
+  const result = next(action)
+  return Promise.resolve(result).then(() => {
+    postSpy(store.getState())
+  })
 }
 
 const prevPreSpy = sinon.spy()
@@ -61,13 +63,12 @@ describe('e2e test with redux API', () => {
     const postSpy = sinon.spy()
     registerPrehook('typeA', preSpy)
     registerPosthook('typeA', postSpy)
-    store.dispatch({ type: 'typeA' })
-
-    expect(prevPreSpy.calledBefore(preSpy)).to.be.true
-    expect(preSpy.calledBefore(nextPreSpy)).to.be.true
-    expect(nextPreSpy.calledBefore(nextPostSpy)).to.be.true
-    expect(nextPostSpy.calledBefore(postSpy)).to.be.true
-    expect(postSpy.calledBefore(prevPostSpy)).to.be.true
-
+    store.dispatch({ type: 'typeA' }).then(() => {
+      expect(prevPreSpy.calledBefore(preSpy)).to.be.true
+      expect(preSpy.calledBefore(nextPreSpy)).to.be.true
+      expect(nextPreSpy.calledBefore(nextPostSpy)).to.be.true
+      expect(nextPostSpy.calledBefore(postSpy)).to.be.true
+      expect(postSpy.calledBefore(prevPostSpy)).to.be.true
+    })
   })
 })

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -76,12 +76,50 @@ describe('middleware', () => {
     registerPrehook('type', pre2)
     registerPosthook('type', post1)
     registerPosthook('type', post2)
-    hookMiddleware(store)(next)(action)
 
-    expect(pre1.calledBefore(next)).to.be.true
-    expect(pre2.calledBefore(next)).to.be.true
-    expect(post1.calledAfter(next)).to.be.true
-    expect(post2.calledAfter(next)).to.be.true
+    const result = hookMiddleware(store)(next)(action)
+
+    result.then(() => {
+      expect(pre1.calledBefore(next)).to.be.true
+      expect(pre2.calledBefore(next)).to.be.true
+      expect(post1.calledAfter(next)).to.be.true
+      expect(post2.calledAfter(next)).to.be.true
+    })
+
+  })
+  it('execute each hooks in order of [pre], next, [post] for action that returns promise', done => {
+    const store = {}
+    const promiseSpy = sinon.spy()
+
+    // eslint-disable-next-line require-jsdoc
+    const next = sinon.stub().callsFake(() => (
+      Promise.resolve().then(promiseSpy)
+    ))
+
+    const action = { type: 'PROMISE' }
+
+    const pre1 = sinon.spy()
+    const pre2 = sinon.spy()
+    const post1 = sinon.spy()
+    const post2 = sinon.spy()
+    registerPrehook('PROMISE', pre1)
+    registerPrehook('PROMISE', pre2)
+    registerPosthook('PROMISE', post1)
+    registerPosthook('PROMISE', post2)
+
+    const result = hookMiddleware(store)(next)(action)
+
+    result.then(() => {
+      expect(pre1.calledBefore(next)).to.be.true
+      expect(pre2.calledBefore(next)).to.be.true
+      expect(promiseSpy.calledAfter(pre1)).to.be.true
+      expect(promiseSpy.calledAfter(pre2)).to.be.true
+      expect(promiseSpy.calledBefore(post1)).to.be.true
+      expect(promiseSpy.calledBefore(post2)).to.be.true
+      expect(post1.calledAfter(next)).to.be.true
+      expect(post2.calledAfter(next)).to.be.true
+      done()
+    })
 
   })
 })


### PR DESCRIPTION
Thanks for building this middleware @kamataryo. We integrated it, but it didn't support our asynchronous workflows that we use quite a lot with redux.

The main issue was the middleware not returning the result of dispatching the action, which is necessary for async calls, such as fetching data from an API which you can then use the data for in your app, e.g.

```
myApiCall().then(response => {
  // do something with response
})
```

I added support by wrapping the next call result with `Promise.resolve` which will work for both promise and non-promise based return values. So it should be fairly transparent and if you do need to do something async promises are a good option.

I'm happy to chat about the pattern of using promises to achieve it, let me know what you think :)