### PR TITLE
Revert to synchronous style middleware

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -93,6 +93,7 @@ export default store => next => action => {
   const posthooks =  getTheHooksAt('post')
 
   prehooks.forEach(hook => hook(store, action))
-  next(action)
+  const result = next(action)
   posthooks.forEach(hook => hook(store, action))
+  return result
 }

--- a/test/e2e/redux.test.js
+++ b/test/e2e/redux.test.js
@@ -28,8 +28,9 @@ const reducer = (state = { case: '' }, action) => {
  */
 const createSpyMiddleware = (preSpy, postSpy) => store => next => action => {
   preSpy(store.getState())
-  next(action)
+  const result = next(action)
   postSpy(store.getState())
+  return result
 }
 
 const prevPreSpy = sinon.spy()
@@ -62,12 +63,10 @@ describe('e2e test with redux API', () => {
     registerPrehook('typeA', preSpy)
     registerPosthook('typeA', postSpy)
     store.dispatch({ type: 'typeA' })
-
     expect(prevPreSpy.calledBefore(preSpy)).to.be.true
     expect(preSpy.calledBefore(nextPreSpy)).to.be.true
     expect(nextPreSpy.calledBefore(nextPostSpy)).to.be.true
     expect(nextPostSpy.calledBefore(postSpy)).to.be.true
     expect(postSpy.calledBefore(prevPostSpy)).to.be.true
-
   })
 })

--- a/test/unit/index.test.js
+++ b/test/unit/index.test.js
@@ -65,8 +65,8 @@ describe('middleware', () => {
   it('execute each hooks in order of [pre], next, [post]', () => {
     const store = {}
     // eslint-disable-next-line require-jsdoc
-    const next = sinon.spy()
     const action = { type: 'type' }
+    const next = sinon.stub().returns(action)
 
     const pre1 = sinon.spy()
     const pre2 = sinon.spy()
@@ -76,8 +76,10 @@ describe('middleware', () => {
     registerPrehook('type', pre2)
     registerPosthook('type', post1)
     registerPosthook('type', post2)
-    hookMiddleware(store)(next)(action)
 
+    const result = hookMiddleware(store)(next)(action)
+
+    expect(result).to.equal(action)
     expect(pre1.calledBefore(next)).to.be.true
     expect(pre2.calledBefore(next)).to.be.true
     expect(post1.calledAfter(next)).to.be.true


### PR DESCRIPTION
Wrapping action to support promises was unnecessary, we just need to make sure we return the action in case the result of the action is a promise object.